### PR TITLE
Use path of PostCSS output as default base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ dist/
 ### Plugin options
 
 #### `base`
-The base path where the plugin will copy images, fonts, and other assets it finds in CSS `url()` declarations. Only `url()` declarations with relative paths are processed. Each asset's sub-directory hierarchy will be maintained under the base path. Basically, sub-directories after the last `../` in the path will be kept (or the whole path if no `../` exists). For example, the image referred to by `url("../../images/icons/icon.jpg")` will be copied to `<base>/images/icons/icon.jpg`.
+Optional base path where the plugin will copy images, fonts, and other assets it finds in CSS `url()` declarations. Only `url()` declarations with relative paths are processed. Each asset's sub-directory hierarchy will be maintained under the base path. Basically, sub-directories after the last `../` in the path will be kept (or the whole path if no `../` exists). For example, the image referred to by `url("../../images/icons/icon.jpg")` will be copied to `<base>/images/icons/icon.jpg`.
+
+If `base` is not specified assets will be copied by default to the base directory given to the PostCSS `to` option while still maintaining the assets' sub-directory hierarchy.  For example, if PostCSS is told to ouput to `dist/css/foo.css` and `base` is not specified the image referred to by `url("../../images/icons/icon.jpg")` will be copied to `dist/css/images/icons/icon.jpg`.  
 
 ### PostCSS options
 

--- a/index.js
+++ b/index.js
@@ -141,11 +141,6 @@ module.exports = postcss.plugin('postcss-copy-assets', function (copyOpts) {
     copyOpts = copyOpts || {};
     return function (css, result) {
         var postCssOpts = result.opts;
-        if (!copyOpts.base) {
-            result.warn('postcss-copy-assets requires "base" option so it ' +
-                'knows where to copy assets.');
-            return;
-        }
         if (!postCssOpts.from) {
             result.warn('postcss-copy-assets requires postcss "from" option.');
             return;
@@ -153,6 +148,10 @@ module.exports = postcss.plugin('postcss-copy-assets', function (copyOpts) {
         if (!postCssOpts.to || postCssOpts.to === postCssOpts.from) {
             result.warn('postcss-copy-assets requires postcss "to" option.');
             return;
+        }
+        if (!copyOpts.base) {
+            var str = postCssOpts.to;
+            copyOpts.base = str.substring(0, str.lastIndexOf('/'));
         }
         var assetBase = path.resolve(copyOpts.base);
         css.walkDecls(function (decl) {

--- a/index.js
+++ b/index.js
@@ -150,8 +150,7 @@ module.exports = postcss.plugin('postcss-copy-assets', function (copyOpts) {
             return;
         }
         if (!copyOpts.base) {
-            var str = postCssOpts.to;
-            copyOpts.base = str.substring(0, str.lastIndexOf('/'));
+            copyOpts.base = path.dirname(postCssOpts.to);
         }
         var assetBase = path.resolve(copyOpts.base);
         css.walkDecls(function (decl) {

--- a/test/test.js
+++ b/test/test.js
@@ -112,19 +112,19 @@ describe('postcss-copy-assets', function () {
              opts, 1, done);
     });
 
-    it('warns if no "base" option provided', function (done) {
-        delete opts.plugin;
-        test('a{ background: url("foo") }',
-             'a{ background: url("foo") }',
-             null,
-             opts, 1, done);
-    });
-
     it('warns if asset file not there', function (done) {
         test('a{ background: url("test-not-there.png") }',
              'a{ background: url("../test-not-there.png") }',
              null,
              opts, 1, done);
+    });
+
+    it('uses "to" base path if no "base" option provided', function (done) {
+        delete opts.plugin;
+        test('a{ background: url("fonts/testfont1.ttf") }',
+             'a{ background: url("fonts/testfont1.ttf") }',
+             ['test/dist/assets/css/fonts/testfont1.ttf'],
+             opts, 0, done);
     });
 
     it('ignores root-relative url()', function (done) {


### PR DESCRIPTION
This allows one to simply copy the file assets to PostCSS's "to" destination folder if this plugins' "base" option is not specified.

This way if you do not have a specific destination in mind the plugin can now be used with zero configuration.
